### PR TITLE
fix: correct typo in the CheckRestart type

### DIFF
--- a/types/CheckRestart.dhall
+++ b/types/CheckRestart.dhall
@@ -1,2 +1,2 @@
 {- https://www.nomadproject.io/docs/job-specification/check_restart -}
-{ limit : Natural, grace : Text, ignore_warning : Bool }
+{ limit : Natural, grace : Text, ignore_warnings : Bool }


### PR DESCRIPTION
The ignore_warning attribute should be ignore_warnings.
